### PR TITLE
Don't use ssl, for reals

### DIFF
--- a/dynalite/Dockerfile
+++ b/dynalite/Dockerfile
@@ -16,4 +16,4 @@ ENV PORT 4567
 EXPOSE $PORT
 
 # Start the Dynalite server
-CMD dynalite --port $PORT --ssl false
+CMD dynalite --port $PORT


### PR DESCRIPTION
`--ssl false` actually _enables_ ssl. The `--ssl` flag doesn't take an option, its presence merely enables ssl. `false` is then interpreted (and ignored) as a standalone argument.